### PR TITLE
Accessibility: turn "Find a resource" and "Find an address" placeholder text black

### DIFF
--- a/lincoln_her/media/css/layout-tweaks.css
+++ b/lincoln_her/media/css/layout-tweaks.css
@@ -40,3 +40,9 @@ header#navbar .navbar-header::before {
 .sidenav {
   color: #2c3647;
 }
+
+/* "Find a resource" and "Find an address" placeholder text black */
+.mapboxgl-ctrl-geocoder input::placeholder,
+.select2-search__field::placeholder {
+    color: #000 !important;
+}


### PR DESCRIPTION
Before:

<img width="498" height="467" alt="image" src="https://github.com/user-attachments/assets/1c1c01eb-963a-47e3-8bae-ab7700359b6e" />

After:

<img width="497" height="437" alt="image" src="https://github.com/user-attachments/assets/3fc77f02-c941-40c8-abb6-15d755c8d517" />
