### PR TITLE
Add migration for making accessibility statement public

### DIFF
--- a/lincoln_her/migrations/0001_accessibility_statement_perms.py
+++ b/lincoln_her/migrations/0001_accessibility_statement_perms.py
@@ -4,6 +4,8 @@ from django.utils.translation import gettext as _
 
 class Migration(migrations.Migration):
 
+    initial = True
+
     dependencies = [("arches_her", "0001_initial")]
 
     add_accessibility_statement_perms = """

--- a/lincoln_her/migrations/0001_accessibility_statement_perms.py
+++ b/lincoln_her/migrations/0001_accessibility_statement_perms.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+from django.utils.translation import gettext as _
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("arches_her", "0001_initial")]
+
+    add_accessibility_statement_perms = """
+        insert into guardian_groupobjectpermission (
+            object_pk,
+            content_type_id,
+            group_id,
+            permission_id)
+        values (
+            '8688eaf9-3605-4384-823c-d01c0d210f82',
+            51,
+            8,
+            205);
+    """
+
+    remove_accessibility_statement_perms = """
+        delete from guardian_groupobjectpermission where 
+        object_pk = '8688eaf9-3605-4384-823c-d01c0d210f82' and
+        content_type_id = 51 and
+        group_id = 8 and
+        permission_id = 205;
+    """
+
+    operations = [
+        migrations.RunSQL(
+            add_accessibility_statement_perms,
+            remove_accessibility_statement_perms,
+        ),
+    ]


### PR DESCRIPTION
Closes #26 

Introduces the first migration to adding a permission to django guardian `guardian_groupobjectpermission` with the plugin UUID (as defined in Arches for HERs), the guest group id 8 found in `auth_group`, the "can view plugin" id 205 found in `auth_permission`, and the content type 51 for the plugin model found in `django_content_type`.

The uncertainties I have are whether these IDs are consistent in core Arches (and thus all Arches projects) or random.

I also wonder whether the migration should be called 0001_accessibility_statement_perms, or 0001_initial, or include the issue number 0026_accessibility_statement_perms. Most apps start with initial. I'm unsure whether it needs to be initial (with the `initial=True` flag) since we are using Arches that has already been initialised, and thus extending. Arches for Science, Arches for HERs etc all have an initial migration, but this includes setting up app specific customisations such as new plugins.