### PR TITLE
Fix index padding issues

### DIFF
--- a/lincoln_her/templates/index.htm
+++ b/lincoln_her/templates/index.htm
@@ -81,13 +81,13 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
       <p>{% trans "Click one of the buttons below to find out about the ways you can search Arcade." %}</p>
 
       <div class="row callouts" >
-        <div class="col-md-4" >
+        <div class="col-md-4 pad-no" >
           <a class="btn btn-outline btn-default" href="{% url 'search_home' %}" role="button"><i class="aa-icon-map" ></i>{% trans "Map Search &gt;" %}</a>
         </div>
-        <div class="col-md-4" >
+        <div class="col-md-4 pad-no" >
           <a class="btn btn-outline btn-default" href="{% url 'search_home' %}?selected_filter=timeFilter" role="button"><i class="aa-icon-stopwatch" ></i>{% trans "Time Search &gt;" %}</a>
         </div>
-        <div class="col-md-4" >
+        <div class="col-md-4 pad-no" >
           <a class="btn btn-outline btn-default" href="{% url 'search_home' %}?selected_filter=advancedFilter" role="button"><i class="aa-icon-relationship" ></i>{% trans "Advanced Search &gt;" %}</a>
         </div>
       </div>
@@ -98,7 +98,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
   <!-- Promoted searches -->
   <section class="container portfolio">
     <div class="row">
-      <div class="col-sm-4 col-xs-12">
+      <div class="col-sm-4 pad-no col-xs-12">
         <a href="{% url 'search_home' %}?termFilter=%5B%7B%22context%22%3A%22adf6690a-fbf0-41f9-a177-dfacbd3eb058%22%2C%22context_label%22%3A%22ROMAN%22%2C%22id%22%3A0%2C%22text%22%3A%22ROMAN%22%2C%22type%22%3A%22concept%22%2C%22value%22%3A%22adf6690a-fbf0-41f9-a177-dfacbd3eb058%22%2C%22inverted%22%3Afalse%7D%5D&typeFilter=%5B%7B%22graphid%22%3A%22e4b3562b-343a-11e8-b509-dca90488358a%22%2C%22name%22%3A%22Heritage%20Assets%22%2C%22inverted%22%3Afalse%7D%5D&no_filters=false&page=1" class="entry">
           <img src="{% static 'img/landing/roman-lincoln.jpg' %}" alt="West gate of Roman Lincoln lower city.">
           <div class="ol">
@@ -111,7 +111,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
           </div>
         </a>
       </div>
-      <div class="col-sm-4 col-xs-12">
+      <div class="col-sm-4 pad-no col-xs-12">
         <a href="{% url 'search_home' %}?termFilter=%5B%7B%22context%22%3A%225f654c6b-d96a-455e-a9d2-85c113deedaa%22%2C%22context_label%22%3A%22POST%20MEDIEVAL%22%2C%22id%22%3A0%2C%22text%22%3A%22POST%20MEDIEVAL%22%2C%22type%22%3A%22concept%22%2C%22value%22%3A%225f654c6b-d96a-455e-a9d2-85c113deedaa%22%2C%22inverted%22%3Afalse%7D%2C%7B%22context%22%3A%224f9e2073-a596-4583-b4fa-f07a9d2096a0%22%2C%22context_label%22%3A%22INDUSTRIAL%22%2C%22id%22%3A0%2C%22text%22%3A%22INDUSTRIAL%22%2C%22type%22%3A%22concept%22%2C%22value%22%3A%224f9e2073-a596-4583-b4fa-f07a9d2096a0%22%2C%22inverted%22%3Afalse%7D%5D&no_filters=false&page=1"  class="entry">
           <img src="{% static 'img/landing/industrial-lincoln.jpg' %}" alt="Ellis Mill at sunset.">
           <div class="ol">
@@ -124,7 +124,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
           </div>
         </a>
       </div>
-      <div class="col-sm-4 col-xs-12">
+      <div class="col-sm-4 pad-no col-xs-12">
         <a href="{% url 'search_home' %}?termFilter=%5B%7B%22context%22%3A%22fde52573-63e6-457a-90ea-42d8e61d4a7b%22%2C%22context_label%22%3A%22MEDIEVAL%22%2C%22id%22%3A0%2C%22text%22%3A%22MEDIEVAL%22%2C%22type%22%3A%22concept%22%2C%22value%22%3A%22fde52573-63e6-457a-90ea-42d8e61d4a7b%22%2C%22inverted%22%3Afalse%7D%5D&typeFilter=%5B%7B%22graphid%22%3A%22e4b3562b-343a-11e8-b509-dca90488358a%22%2C%22name%22%3A%22Heritage%20Assets%22%2C%22inverted%22%3Afalse%7D%5D&no_filters=false&page=1"  class="entry">
           <img src="{% static 'img/landing/designated-heritage.jpg' %}" alt="Jews' Court and Steep Hill Lincoln">
           <div class="ol">
@@ -151,10 +151,10 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
   </div>
   
   <!-- .search-styles -->
-  <section class="col-layout">
+  <section class="col-layout pad-no">
     <div class="container">
       <div class="row" >
-        <div class="col-md-5">
+        <div class="col-md-5 pad-no">
           <h3>{% trans "Search Styles"  %}</h3>
           <p>{% trans "Arcade lets you explore Lincoln's rich heritage in new ways &dash; from an individual historic building, to the development of the Roman city of Lindum Colonia. Explore the Arcade site and use our powerful search engine to discover more about this ancient city" %}</p>
         </div>
@@ -185,17 +185,17 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
   </div>
   
   <!-- .about -->
-  <section class="col-layout">
+  <section class="col-layout pad-no">
     <div class="container">
       <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-6 pad-no">
           <h3>{% trans "About Arcade" %}</h3>
           <h4>{% trans "Who was involved?" %}</h4>
           <p>Arcade is the result of a partnership between the City of Lincoln Council and the Getty Conservation Institute,
             with the assistance of Historic England. It is powered by Arches, an open source heritage data management platform developed by 
             the Getty Conservation Institute and the World Monuments Fund.</p>
         </div>
-        <div class="col-md-5 col-md-offset-1 callouts">
+        <div class="col-md-5 col-md-offset-1 callouts pad-no">
           <div>
             <img src="{% static 'img/landing/COLC_Black_Logo.png' %}" alt="City of Lincoln Council black logo"/>
           </div>
@@ -206,7 +206,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
   <!-- ./about -->
   
   <!-- .contact -->
-  <section class="col-layout">
+  <section class="col-layout pad-no">
     <div class="container">
       <h3>{% trans "Get in Touch" %}</h3>
       <p>City of Lincoln Council<br />


### PR DESCRIPTION
Arches 7.6 has a new core CSS class [here](https://github.com/archesproject/arches/blob/5184f9db4e008ac796e39caaff706e0f6d6e2e78/arches/app/media/css/arches.scss#L44-L47):
```
[class^="col-"]:not(.pad-no) {
    padding-left: 0px;
    padding-right: 0px;
}
```

Thus removing any padding we had for index css classes beginning with col, e.g. `class="col-layout"` or `<div class="col-md-4">`

This PR adds `pad-no`, so the padding is not removed and we can continue to use the core CSS, without requiring any changes.