### PR TITLE
Remove term filter i18n search box

### DIFF
--- a/lincoln_her/templates/views/components/search/term-filter.htm
+++ b/lincoln_her/templates/views/components/search/term-filter.htm
@@ -10,8 +10,8 @@
             "
         ></select>
         
-        {% if show_language_swtich %}
-        <select data-bind="
+        <!-- Commented out to remove i18n dropdown -->
+        <!-- <select data-bind="
             options: languages, 
             optionsValue: 'code',
             optionsText: function(item){return item.name + ' (' + item.code + ')'}, 
@@ -21,8 +21,7 @@
                     allowClear: false
             }},
             attr: {'data-label': $root.translations.language}"
-        ></select>
-        {% endif %}
+        ></select> -->
 
     </form>
 </div>

--- a/lincoln_her/templates/views/components/search/term-filter.htm
+++ b/lincoln_her/templates/views/components/search/term-filter.htm
@@ -1,0 +1,29 @@
+{% load i18n %}
+
+<!-- Term Filter -->
+<div class="term-search-filter">
+    <form autocomplete="off">
+        <select style="width:100%;"
+            data-bind="
+                attr: {'data-label': $root.translations.findAResource, 'aria-label': $root.translations.findAResource},
+                termSearch: {terms: filter.terms, language: language, tags: filter.tags, placeholder: $root.translations.findAResource}
+            "
+        ></select>
+        
+        {% if show_language_swtich %}
+        <select data-bind="
+            options: languages, 
+            optionsValue: 'code',
+            optionsText: function(item){return item.name + ' (' + item.code + ')'}, 
+            select2Query: {
+                select2Config:{
+                    value: language,
+                    allowClear: false
+            }},
+            attr: {'data-label': $root.translations.language}"
+        ></select>
+        {% endif %}
+
+    </form>
+</div>
+<!-- End Term Filter -->


### PR DESCRIPTION
While this PR just adds the term-filter html file and comments out the component, there could be scope to submit this back to core Arches - e.g. only show the dropdown where `SHOW_LANGUAGE_SWITCH` is True. Unfortunately term-filter does not share the same context as base-manager and index, so we can't use `{% if show_language_swtich %}`. We also can't add a query in term-filter.js with languages, because that language list is what exists within Django, not the settings.py LANGUAGES list.